### PR TITLE
Port to `no_std`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: stable
+            toolchain: beta
             components: rustfmt
             override: true
       - uses: mbrobbel/rustfmt-check@0.2.0
@@ -33,7 +33,7 @@ jobs:
         key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: beta
         target: x86_64-unknown-linux-gnu
         override: true
     - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,16 +26,16 @@ use-serde = ["serde", "uom/use_serde"]
 [dependencies]
 casey = "0.3"
 lazy_static = "1"
-uom = { version = "0" }
+uom = { version = "0", default-features = false, features = [ "f64", "si", "use_serde" ] }
 ringbuffer = "0.4"
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
+arbitrary = { version = "1", features = ["derive"] }
 async-trait = "^0.1.41"
-cucumber = { package = "cucumber_rust", git = "https://github.com/bbqsrc/cucumber-rust", branch = "main" } # TODO revert to regular release
+cucumber = { package = "cucumber_rust", version = "0.8" }
 futures = "0"
-quickcheck = "^0.9.2"
-rand = "0.7"
+#rand = "0.7"
 
 # for examples/flightgear
 async-tungstenite = { version = "*", features = [ "async-std-runtime" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ cucumber = { package = "cucumber_rust", version = "0.8" }
 futures = "0"
 rand = "*"
 rand_pcg = "*"
+uom = { version = "*", features = [ "f64", "si", "std", "use_serde" ] }
 
 # for examples/flightgear
 async-tungstenite = { version = "*", features = [ "async-std-runtime" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,15 @@ is-it-maintained-open-issues = { repository = "aeronautical-informatics/openTAWS
 maintenance = { status = "actively-developed" }
 
 [features]
-default = [ ]
+default = ["use-serde"]
+use-serde = ["serde", "uom/use_serde"]
 
 [dependencies]
 casey = "0.3"
 lazy_static = "1"
-uom = "0"
-strum = { version = "^0.19", features = ["derive"]}
-ringbuffer = "^0.4"
+uom = { version = "0" }
+ringbuffer = "0.4"
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 async-trait = "^0.1.41"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,11 @@ serde = { version = "1.0", default-features = false, features = ["derive"], opti
 
 [dev-dependencies]
 arbitrary = { version = "1", features = ["derive"] }
-async-trait = "^0.1.41"
+async-trait = "0.1"
 cucumber = { package = "cucumber_rust", version = "0.8" }
 futures = "0"
-#rand = "0.7"
+rand = "*"
+rand_pcg = "*"
 
 # for examples/flightgear
 async-tungstenite = { version = "*", features = [ "async-std-runtime" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ maintenance = { status = "actively-developed" }
 default = [ ]
 
 [dependencies]
+casey = "0.3"
 lazy_static = "1"
 uom = "0"
 strum = { version = "^0.19", features = ["derive"]}

--- a/examples/flightgear.rs
+++ b/examples/flightgear.rs
@@ -66,18 +66,17 @@ const USAGE: &'static str = "usage: <Flightgear base url>";
 fn main() -> Result<(), Box<dyn Error>> {
     smol::block_on(async {
         let args: Vec<String> = env::args().collect();
-        let base_url = args.get(1).expect(USAGE);
+        let base_uri = args.get(1).expect(USAGE);
 
         let mut taws = TAWS::new(Default::default());
-        let mut fg_stream = new_flightgear_stream(base_url.as_str()).await?;
+        let mut fg_stream = new_flightgear_stream(base_uri.as_str()).await?;
         let mut frames: u128 = 0;
 
         let mut aircraft_state = AircraftState::default();
 
         loop {
-            let now = Instant::now();
-
             let leaf = fg_stream.next().await.unwrap()?;
+            let now = Instant::now();
             let ts = Time::new::<second>(leaf.ts);
 
             // Next frame begins

--- a/examples/flightgear.rs
+++ b/examples/flightgear.rs
@@ -68,7 +68,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         let args: Vec<String> = env::args().collect();
         let base_uri = args.get(1).expect(USAGE);
 
-        let mut taws = TAWS::new(Default::default());
+        let mut taws = Taws::new(Default::default());
         let mut fg_stream = new_flightgear_stream(base_uri.as_str()).await?;
         let mut frames: u128 = 0;
 

--- a/features/mode_1.feature
+++ b/features/mode_1.feature
@@ -14,7 +14,7 @@ Feature: Mode 1: Excessive Rate of Descent
     Given the plane is flying
     Then Mode 1 shall be armed
 
-  #Rule: Standard Caution Envelope (MOPS_269, MOPS_270)
+    #Rule: Standard Caution Envelope (MOPS_269, MOPS_270)
 
     @MOPS_269
     Scenario Outline: Must Alert
@@ -29,22 +29,22 @@ Feature: Mode 1: Excessive Rate of Descent
         | rate of descent | height |
         | 1560            | 100    |
         | 2200            | 630    |
-        | 5700            | 100    |
+        | 5700            | 2200   |
 
     @MOPS_270
     Scenario: Must Not Alert when not Armed
       Given Mode 1 is not armed
-      Then a caution alert is not emitted at all
+      Then a Mode 1 caution alert is not emitted at all
 
     @MOPS_270
     Scenario: Must Not Alert when Inhibited
       Given Mode 1 is inhibited
-      Then a caution alert is not emitted at all
+      Then a Mode 1 caution alert is not emitted at all
 
     @MOPS_270
     Scenario Outline: Must Not Alert
       Given steep approach is not selected
-      When the rate of descent is at least <rate of descent> feet per minute
+      When the rate of descent is at most <rate of descent> feet per minute
       But the height above terrain is not between 10 and <height> feet
       Then a Mode 1 caution alert is not emitted at all
 
@@ -88,7 +88,7 @@ Feature: Mode 1: Excessive Rate of Descent
     @MOPS_272
     Scenario Outline: Must Not Alert
       Given steep approach is selected
-      When the rate of descent is at least <rate of descent> feet per minute
+      When the rate of descent is at most <rate of descent> feet per minute
       But the height above terrain is not between 10 and <height> feet
       Then a Mode 1 caution alert is not emitted at all
 
@@ -110,7 +110,7 @@ Feature: Mode 1: Excessive Rate of Descent
       And steep approach is not selected
       When the rate of descent is at least <rate of descent> feet per minute
       And the height above terrain is between 100 and <height> feet
-      Then a Mode 1 caution alert is emitted within 2 seconds
+      Then a Mode 1 warning alert is emitted within 2 seconds
 
       Examples:
         | rate of descent | height |
@@ -121,19 +121,19 @@ Feature: Mode 1: Excessive Rate of Descent
     @MOPS_274
     Scenario: Must Not Alert when not Armed
       Given Mode 1 is not armed
-      Then a Mode 1 caution alert is not emitted at all
+      Then a Mode 1 warning alert is not emitted at all
 
     @MOPS_274
     Scenario: Must Not Alert when Inhibited
       Given Mode 1 is inhibited
-      Then a Mode 1 caution alert is not emitted at all
+      Then a Mode 1 warning alert is not emitted at all
 
     @MOPS_274
     Scenario Outline: Must Not Alert
       Given steep approach is not selected
-      When the rate of descent is at least <rate of descent> feet per minute
+      When the rate of descent is at most <rate of descent> feet per minute
       But the height above terrain is not between 10 and <height> feet
-      Then a Mode 1 caution alert is not emitted at all
+      Then a Mode 1 warning alert is not emitted at all
 
       Examples:
         | rate of descent | height |
@@ -152,7 +152,7 @@ Feature: Mode 1: Excessive Rate of Descent
       And steep approach is selected
       When the rate of descent is at least <rate of descent> feet per minute
       And the height above terrain is between 150 and <height> feet
-      Then a Mode 1 caution alert is emitted within 2 seconds
+      Then a Mode 1 warning alert is emitted within 2 seconds
 
       Examples:
         | rate of descent | height |
@@ -163,19 +163,19 @@ Feature: Mode 1: Excessive Rate of Descent
     @MOPS_276
     Scenario: Must Not Alert when not Armed
       Given Mode 1 is not armed
-      Then a Mode 1 caution alert is not emitted at all
+      Then a Mode 1 warning alert is not emitted at all
 
     @MOPS_276
     Scenario: Must Not Alert when Inhibited
       Given Mode 1 is inhibited
-      Then a Mode 1 caution alert is not emitted at all
+      Then a Mode 1 warning alert is not emitted at all
 
     @MOPS_276
     Scenario Outline: Must Not Alert
       Given steep approach is selected
-      When the rate of descent is at least <rate of descent> feet per minute
+      When the rate of descent is at most <rate of descent> feet per minute
       But the height above terrain is not between 10 and <height> feet
-      Then a Mode 1 caution alert is not emitted at all
+      Then a Mode 1 warning alert is not emitted at all
 
       Examples:
         | rate of descent | height |

--- a/src/alerts/ffac.rs
+++ b/src/alerts/ffac.rs
@@ -8,6 +8,13 @@ pub struct FFAC {
 }
 
 impl AlertSystem for FFAC {
+    fn new(_config: &TAWSConfig) -> Self {
+        Self {
+            inhibited: false,
+            last_height: Length::new::<foot>(0.0),
+        }
+    }
+
     fn is_armed(&self) -> bool {
         true
     }
@@ -37,15 +44,3 @@ impl AlertSystem for FFAC {
         None
     }
 }
-
-impl Default for FFAC {
-    fn default() -> Self {
-        Self {
-            inhibited: false,
-            last_height: Length::new::<foot>(0.0),
-        }
-    }
-}
-
-// TODO is this sound usage?
-impl std::panic::UnwindSafe for FFAC {}

--- a/src/alerts/ffac.rs
+++ b/src/alerts/ffac.rs
@@ -2,13 +2,13 @@ use super::*;
 use crate::prelude::*;
 
 #[derive(Debug)]
-pub struct FFAC {
+pub struct Ffac {
     inhibited: bool,
     last_height: Length,
 }
 
-impl AlertSystem for FFAC {
-    fn new(_config: &TAWSConfig) -> Self {
+impl AlertSystem for Ffac {
+    fn new(_config: &TawsConfig) -> Self {
         Self {
             inhibited: false,
             last_height: Length::new::<foot>(0.0),

--- a/src/alerts/flta.rs
+++ b/src/alerts/flta.rs
@@ -1,13 +1,13 @@
 use super::*;
 
 #[derive(Debug)]
-pub struct FLTA {
+pub struct Flta {
     armed: bool,
     inhibited: bool,
 }
 
-impl AlertSystem for FLTA {
-    fn new(_config: &TAWSConfig) -> Self {
+impl AlertSystem for Flta {
+    fn new(_config: &TawsConfig) -> Self {
         Self {
             armed: false,
             inhibited: false,

--- a/src/alerts/flta.rs
+++ b/src/alerts/flta.rs
@@ -4,6 +4,10 @@ use super::*;
 pub struct FLTA();
 
 impl AlertSystem for FLTA {
+    fn new(_config: &TAWSConfig) -> Self {
+        Self()
+    }
+
     fn is_armed(&self) -> bool {
         false
     }

--- a/src/alerts/flta.rs
+++ b/src/alerts/flta.rs
@@ -1,11 +1,17 @@
 use super::*;
 
 #[derive(Debug)]
-pub struct FLTA();
+pub struct FLTA {
+    armed: bool,
+    inhibited: bool,
+}
 
 impl AlertSystem for FLTA {
     fn new(_config: &TAWSConfig) -> Self {
-        Self()
+        Self {
+            armed: false,
+            inhibited: false,
+        }
     }
 
     fn is_armed(&self) -> bool {
@@ -13,15 +19,15 @@ impl AlertSystem for FLTA {
     }
 
     fn is_inhibited(&self) -> bool {
-        unimplemented!()
+        self.inhibited
     }
 
     fn inhibit(&mut self) {
-        unimplemented!()
+        self.inhibited = true;
     }
 
     fn uninhibit(&mut self) {
-        unimplemented!()
+        self.inhibited = false;
     }
 
     fn process(&mut self, _state: &AircraftState) -> Option<AlertLevel> {

--- a/src/alerts/mod.rs
+++ b/src/alerts/mod.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use crate::types::{AircraftState, TAWSConfig};
+use crate::types::{AircraftState, TawsConfig};
 
 mod ffac;
 mod flta;
@@ -29,13 +29,13 @@ pub mod functionalities {
 #[cfg_attr(feature = "use-serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Alert {
     /// Forward Lookig Terrain Avoidance
-    FLTA,
+    Flta,
 
     /// Five Hundred foot altitude Callout
-    FFAC,
+    Ffac,
 
     /// Premature Descent Alerting
-    PDA,
+    Pda,
 
     /// Excessive Rate of Descent
     Mode1,
@@ -85,11 +85,11 @@ pub fn priority(alert: Alert, alert_level: AlertLevel) -> u8 {
     match (alert, alert_level) {
         (Mode1, Warning) => 2,
         (Mode2, Warning) => 3,
-        (FLTA, Warning) => 6,
+        (Flta, Warning) => 6,
         (Mode2, Caution) => 9,
-        (FLTA, Caution) => 11,
+        (Flta, Caution) => 11,
         (Mode4, Caution) => 13, // Terrain caution
-        (PDA, Caution) => 14,
+        (Pda, Caution) => 14,
         //(Mode4, Caution)=>16 // Gear caution
         //(Mode4, Caution)=>17 // Flaps caution
         (Mode1, Caution) => 18,
@@ -183,7 +183,7 @@ impl IntoIterator for &AlertState {
     type Item = (Alert, AlertLevel);
     type IntoIter = AlertStateIter;
     fn into_iter(self) -> Self::IntoIter {
-        let mut alerts = self.all_alerts.clone();
+        let mut alerts = self.all_alerts;
         alerts.sort_by_key(|option| option.map(|(a, l)| priority(a, l)).unwrap_or(u8::MAX));
 
         AlertStateIter {
@@ -196,7 +196,7 @@ impl IntoIterator for &AlertState {
 /// Trait which is to be fulfilled by all functionalities
 pub trait AlertSystem: fmt::Debug + Send {
     /// Allows this system to be instantiated
-    fn new(config: &TAWSConfig) -> Self
+    fn new(config: &TawsConfig) -> Self
     where
         Self: Sized;
 

--- a/src/alerts/mod.rs
+++ b/src/alerts/mod.rs
@@ -26,6 +26,7 @@ pub mod functionalities {
 
 /// Available alerts from the TAWS.
 #[derive(Clone, Copy, Debug, PartialEq, Hash)]
+#[cfg_attr(feature = "use-serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Alert {
     /// Forward Lookig Terrain Avoidance
     FLTA,
@@ -58,7 +59,7 @@ impl Eq for Alert {}
 ///
 /// Orderd by high priority to low priority (top to bottom)
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Hash)]
-//#[strum(serialize_all = "kebab_case")]
+#[cfg_attr(feature = "use-serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum AlertLevel {
     /// The level or category of alert for conditions that require immediate flight crew awareness
     /// and immediate flight crew response.
@@ -117,9 +118,9 @@ impl AlertState {
         self.all_alerts
             .iter()
             .filter_map(|o| {
-                o.map(|(alert, alert_level)| ((priority(alert, alert_level), (alert, alert_level))))
+                o.map(|(alert, alert_level)| (priority(alert, alert_level), (alert, alert_level)))
             })
-            .min_by_key(|(p, _)| p.clone())
+            .min_by_key(|(p, _)| *p)
             .map(|(_, alert_stuff)| alert_stuff)
     }
 
@@ -147,7 +148,7 @@ impl AlertState {
 
         // lets find a free spot
         if !already_present {
-            if let Some(option) = self.all_alerts.iter_mut().filter(|e| e.is_none()).next() {
+            if let Some(option) = self.all_alerts.iter_mut().find(|e| e.is_none()) {
                 *option = Some((new_alert, new_alert_level));
             }
         }

--- a/src/alerts/mod.rs
+++ b/src/alerts/mod.rs
@@ -104,6 +104,7 @@ const ALERT_STATE_SIZE: usize = 8;
 
 /// Collection of a all alerts which are currently present in the TAWS
 #[derive(Debug, PartialEq)]
+#[cfg_attr(feature = "use-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AlertState {
     /// Alerts which are not to be disclosed to the crew to avoid nuisance, but still where triggered
     all_alerts: [Option<(Alert, AlertLevel)>; ALERT_STATE_SIZE],

--- a/src/alerts/mod.rs
+++ b/src/alerts/mod.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
+use core::fmt;
 
-use crate::types::AircraftState;
+use crate::types::{AircraftState, TAWSConfig};
 
 mod ffac;
 mod flta;
@@ -11,17 +11,21 @@ mod mode_4;
 mod mode_5;
 mod pda;
 
-pub use ffac::*;
-pub use flta::*;
-pub use mode_1::*;
-pub use mode_2::*;
-pub use mode_3::*;
-pub use mode_4::*;
-pub use mode_5::*;
-pub use pda::*;
+pub mod functionalities {
+    use super::*;
+
+    pub use ffac::*;
+    pub use flta::*;
+    pub use mode_1::*;
+    pub use mode_2::*;
+    pub use mode_3::*;
+    pub use mode_4::*;
+    pub use mode_5::*;
+    pub use pda::*;
+}
 
 /// Available alerts from the TAWS.
-#[derive(Clone, Copy, Debug, PartialEq, Hash, strum::EnumString)]
+#[derive(Clone, Copy, Debug, PartialEq, Hash)]
 pub enum Alert {
     /// Forward Lookig Terrain Avoidance
     FLTA,
@@ -53,8 +57,8 @@ impl Eq for Alert {}
 /// Importance level of an alert
 ///
 /// Orderd by high priority to low priority (top to bottom)
-#[derive(Clone, Copy, Debug, PartialEq, Hash, strum::EnumString)]
-#[strum(serialize_all = "kebab_case")]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Hash)]
+//#[strum(serialize_all = "kebab_case")]
 pub enum AlertLevel {
     /// The level or category of alert for conditions that require immediate flight crew awareness
     /// and immediate flight crew response.
@@ -70,44 +74,131 @@ pub enum AlertLevel {
 }
 impl Eq for AlertLevel {}
 
-/// Collection of a all alerts which are currently present in the TAWS
-#[derive(Debug, Default, PartialEq)]
-pub struct AlertState {
-    /// Alerts which are to be displayed to the crew
-    pub alerts: HashMap<Alert, AlertLevel>,
+/// Get the priority of a n (Alert, AlertLevel) tupel
+///
+/// A low value means a high priority.
+pub fn priority(alert: Alert, alert_level: AlertLevel) -> u8 {
+    use Alert::*;
+    use AlertLevel::*;
 
-    /// Alerts which are not to be disclosed to the crew to avoid nuisance
-    pub nuisance_alerts: HashMap<Alert, AlertLevel>,
+    match (alert, alert_level) {
+        (Mode1, Warning) => 2,
+        (Mode2, Warning) => 3,
+        (FLTA, Warning) => 6,
+        (Mode2, Caution) => 9,
+        (FLTA, Caution) => 11,
+        (Mode4, Caution) => 13, // Terrain caution
+        (PDA, Caution) => 14,
+        //(Mode4, Caution)=>16 // Gear caution
+        //(Mode4, Caution)=>17 // Flaps caution
+        (Mode1, Caution) => 18,
+        (Mode3, Caution) => 19,
+        (Mode5, Caution) => 20,
+        _ => u8::MAX, // TODO is this a safe assumption
+    }
+}
+
+/// This is the maximum number of different alerts in an alert_state
+const ALERT_STATE_SIZE: usize = 8;
+
+/// Collection of a all alerts which are currently present in the TAWS
+#[derive(Debug, PartialEq)]
+pub struct AlertState {
+    /// Alerts which are not to be disclosed to the crew to avoid nuisance, but still where triggered
+    all_alerts: [Option<(Alert, AlertLevel)>; ALERT_STATE_SIZE],
 }
 
 impl AlertState {
     pub fn alerts_total_count(&self) -> usize {
-        self.alerts.len() + self.nuisance_alerts.len()
+        self.all_alerts.iter().filter(|e| e.is_some()).count()
     }
 
-    pub fn alerts_count(&self, level: AlertLevel) -> usize {
-        self.alerts.values().filter(|v| **v == level).count()
+    pub fn priority_alert(&self) -> Option<(Alert, AlertLevel)> {
+        self.all_alerts
+            .iter()
+            .filter_map(|o| {
+                o.map(|(alert, alert_level)| ((priority(alert, alert_level), (alert, alert_level))))
+            })
+            .min_by_key(|(p, _)| p.clone())
+            .map(|(_, alert_stuff)| alert_stuff)
     }
 
-    pub fn mode_alert_level(&self, alert_system: Alert) -> Option<AlertLevel> {
-        self.alerts.get(&alert_system).cloned()
+    /// Get an iterator to the alerts
+    pub fn iter(&self) -> impl Iterator<Item = (Alert, AlertLevel)> {
+        self.into_iter()
     }
 
     /// updates internal alerts with new alerts, removing all old alerts. Prioritizes as well.
-    pub(crate) fn insert(&mut self, alert: Alert, alert_level: AlertLevel) {
-        if let Some(old_alert_level) = self.alerts.get_mut(&alert) {
-            if (alert_level as isize) < (*old_alert_level as isize) {
-                self.nuisance_alerts.insert(alert, *old_alert_level);
-                *old_alert_level = alert_level;
+    pub(crate) fn insert(&mut self, new_alert: Alert, new_alert_level: AlertLevel) {
+        let mut already_present = false;
+
+        for (existing_alert, ref mut existing_alert_level) in
+            self.all_alerts.iter_mut().filter_map(|e| *e)
+        {
+            // check if alert is already present
+            if existing_alert == new_alert {
+                // promote alerts of lower priority to higher priority
+                if new_alert_level < *existing_alert_level {
+                    *existing_alert_level = new_alert_level;
+                }
+                already_present = true;
             }
-        } else {
-            self.alerts.insert(alert, alert_level);
+        }
+
+        // lets find a free spot
+        if !already_present {
+            if let Some(option) = self.all_alerts.iter_mut().filter(|e| e.is_none()).next() {
+                *option = Some((new_alert, new_alert_level));
+            }
+        }
+    }
+}
+
+impl Default for AlertState {
+    fn default() -> Self {
+        Self {
+            all_alerts: [None; ALERT_STATE_SIZE],
+        }
+    }
+}
+
+/// An iterator over an `AlertState`
+pub struct AlertStateIter {
+    sorted_alerts: [Option<(Alert, AlertLevel)>; ALERT_STATE_SIZE],
+    index: usize,
+}
+
+impl Iterator for AlertStateIter {
+    type Item = (Alert, AlertLevel);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let maybe_item = self.sorted_alerts.get(self.index).cloned().flatten();
+        self.index += 1;
+        maybe_item
+    }
+}
+
+impl IntoIterator for &AlertState {
+    type Item = (Alert, AlertLevel);
+    type IntoIter = AlertStateIter;
+    fn into_iter(self) -> Self::IntoIter {
+        let mut alerts = self.all_alerts.clone();
+        alerts.sort_by_key(|option| option.map(|(a, l)| priority(a, l)).unwrap_or(u8::MAX));
+
+        AlertStateIter {
+            sorted_alerts: alerts,
+            index: 0,
         }
     }
 }
 
 /// Trait which is to be fulfilled by all functionalities
-pub trait AlertSystem: std::fmt::Debug + Send {
+pub trait AlertSystem: fmt::Debug + Send {
+    /// Allows this system to be instantiated
+    fn new(config: &TAWSConfig) -> Self
+    where
+        Self: Sized;
+
     /// Returns whether this alarm is armed.
     ///
     /// Arming refers to the automatic switching on of a function by
@@ -132,20 +223,10 @@ mod test {
     use super::*;
 
     #[test]
-    pub fn strum_test() {
-        let mut key = String::from("Mode 1");
-        key.retain(|c| !c.is_whitespace());
-
-        let _: Alert = key
-            .parse()
-            .expect(&format!("Unable to parse {} as Alert ", key));
-    }
-
-    #[test]
     pub fn alert_state_propagates_alerts() {
         let mut alert_state = AlertState::default();
-        let test_alerts = vec![(Alert::Mode3, AlertLevel::Caution)];
-        for (new_alert, new_alert_level) in test_alerts.iter() {
+        let test_alerts = [(Alert::Mode3, AlertLevel::Caution)];
+        for (new_alert, new_alert_level) in &test_alerts {
             alert_state.insert(*new_alert, *new_alert_level);
         }
 
@@ -156,18 +237,8 @@ mod test {
     pub fn alert_state_usage() {
         let alts = AlertState::default();
 
-        // using hashset contains
-        if alts.alerts.get(&Alert::Mode1) == Some(&AlertLevel::Caution) {
-            // do important stuff
-        }
-
-        // using hashset any
-        if alts.alerts.iter().any(|(_k, v)| *v == AlertLevel::Caution) {
-            // do important stuff
-        }
-
         // using match
-        for x in &alts.alerts {
+        for x in &alts {
             match x {
                 (Alert::Mode1, AlertLevel::Caution) if 1 > 0 => {}
 
@@ -178,7 +249,7 @@ mod test {
         }
 
         // using match lazily
-        for x in &alts.alerts {
+        for x in &alts {
             match x {
                 (_, AlertLevel::Caution) if 1 > 0 => {}
                 _ => {}

--- a/src/alerts/mode_1.rs
+++ b/src/alerts/mode_1.rs
@@ -21,7 +21,7 @@ impl Default for Mode1 {
 }
 
 impl AlertSystem for Mode1 {
-    fn new(_config: &TAWSConfig) -> Self {
+    fn new(_config: &TawsConfig) -> Self {
         Self {
             armed: true,
             inhibited: false,

--- a/src/alerts/mode_1.rs
+++ b/src/alerts/mode_1.rs
@@ -21,6 +21,13 @@ impl Default for Mode1 {
 }
 
 impl AlertSystem for Mode1 {
+    fn new(_config: &TAWSConfig) -> Self {
+        Self {
+            armed: true,
+            inhibited: false,
+        }
+    }
+
     fn process(&mut self, state: &AircraftState) -> Option<AlertLevel> {
         let altitude = state.altitude_ground.get::<foot>();
         let rod = -state.climb_rate.get::<foot_per_minute>();
@@ -56,7 +63,7 @@ impl AlertSystem for Mode1 {
 
 lazy_static::lazy_static! {
 
-static ref CAUTION_ENVELOPE: Envelope = Envelope::new(&vec![
+static ref CAUTION_ENVELOPE: Envelope<4> = Envelope::new([
             (1560.0, 100.0),
             (2200.0, 630.0),
             (5700.0, 2200.0),
@@ -64,7 +71,7 @@ static ref CAUTION_ENVELOPE: Envelope = Envelope::new(&vec![
         ])
         .unwrap();
 
-        static ref CAUTION_ENVELOPE_STEEP_APPROACH: Envelope = Envelope::new(&vec![
+        static ref CAUTION_ENVELOPE_STEEP_APPROACH: Envelope<5> = Envelope::new([
             (1798.0, 150.0),
             (1944.0, 300.0),
             (3233.0, 1078.0),
@@ -73,7 +80,7 @@ static ref CAUTION_ENVELOPE: Envelope = Envelope::new(&vec![
         ])
         .unwrap();
 
-        static ref WARNING_ENVELOPE: Envelope = Envelope::new(&vec![
+        static ref WARNING_ENVELOPE: Envelope<4> = Envelope::new([
             (1600.0, 100.0),
             (1850.0, 300.0),
             (10100.0, 1958.0),
@@ -81,7 +88,7 @@ static ref CAUTION_ENVELOPE: Envelope = Envelope::new(&vec![
         ])
         .unwrap();
 
-        static ref WARNING_ENVELOPE_STEEP_APPROACH: Envelope = Envelope::new(&vec![
+        static ref WARNING_ENVELOPE_STEEP_APPROACH: Envelope<4> = Envelope::new([
             (1908.0, 150.0),
             (2050.0, 300.0),
             (10300.0, 1958.0),

--- a/src/alerts/mode_2.rs
+++ b/src/alerts/mode_2.rs
@@ -4,6 +4,10 @@ use super::*;
 pub struct Mode2();
 
 impl AlertSystem for Mode2 {
+    fn new(_config: &TAWSConfig) -> Self {
+        Self()
+    }
+
     fn is_armed(&self) -> bool {
         false
     }

--- a/src/alerts/mode_2.rs
+++ b/src/alerts/mode_2.rs
@@ -1,11 +1,17 @@
 use super::*;
 
 #[derive(Debug)]
-pub struct Mode2();
+pub struct Mode2 {
+    armed: bool,
+    inhibited: bool,
+}
 
 impl AlertSystem for Mode2 {
     fn new(_config: &TAWSConfig) -> Self {
-        Self()
+        Self {
+            armed: false,
+            inhibited: false,
+        }
     }
 
     fn is_armed(&self) -> bool {
@@ -13,15 +19,15 @@ impl AlertSystem for Mode2 {
     }
 
     fn is_inhibited(&self) -> bool {
-        unimplemented!()
+        self.inhibited
     }
 
     fn inhibit(&mut self) {
-        unimplemented!()
+        self.inhibited = true;
     }
 
     fn uninhibit(&mut self) {
-        unimplemented!()
+        self.inhibited = false;
     }
 
     fn process(&mut self, _state: &AircraftState) -> Option<AlertLevel> {

--- a/src/alerts/mode_2.rs
+++ b/src/alerts/mode_2.rs
@@ -7,7 +7,7 @@ pub struct Mode2 {
 }
 
 impl AlertSystem for Mode2 {
-    fn new(_config: &TAWSConfig) -> Self {
+    fn new(_config: &TawsConfig) -> Self {
         Self {
             armed: false,
             inhibited: false,

--- a/src/alerts/mode_3.rs
+++ b/src/alerts/mode_3.rs
@@ -4,6 +4,10 @@ use super::*;
 pub struct Mode3();
 
 impl AlertSystem for Mode3 {
+    fn new(_config: &TAWSConfig) -> Self {
+        Self()
+    }
+
     fn is_armed(&self) -> bool {
         false
     }

--- a/src/alerts/mode_3.rs
+++ b/src/alerts/mode_3.rs
@@ -1,11 +1,17 @@
 use super::*;
 
 #[derive(Debug)]
-pub struct Mode3();
+pub struct Mode3 {
+    armed: bool,
+    inhibited: bool,
+}
 
 impl AlertSystem for Mode3 {
     fn new(_config: &TAWSConfig) -> Self {
-        Self()
+        Self {
+            armed: false,
+            inhibited: false,
+        }
     }
 
     fn is_armed(&self) -> bool {
@@ -13,15 +19,15 @@ impl AlertSystem for Mode3 {
     }
 
     fn is_inhibited(&self) -> bool {
-        unimplemented!()
+        self.inhibited
     }
 
     fn inhibit(&mut self) {
-        unimplemented!()
+        self.inhibited = true;
     }
 
     fn uninhibit(&mut self) {
-        unimplemented!()
+        self.inhibited = false;
     }
 
     fn process(&mut self, _state: &AircraftState) -> Option<AlertLevel> {

--- a/src/alerts/mode_3.rs
+++ b/src/alerts/mode_3.rs
@@ -7,7 +7,7 @@ pub struct Mode3 {
 }
 
 impl AlertSystem for Mode3 {
-    fn new(_config: &TAWSConfig) -> Self {
+    fn new(_config: &TawsConfig) -> Self {
         Self {
             armed: false,
             inhibited: false,

--- a/src/alerts/mode_4.rs
+++ b/src/alerts/mode_4.rs
@@ -4,6 +4,10 @@ use super::*;
 pub struct Mode4();
 
 impl AlertSystem for Mode4 {
+    fn new(_config: &TAWSConfig) -> Self {
+        Self()
+    }
+
     fn is_armed(&self) -> bool {
         false
     }

--- a/src/alerts/mode_4.rs
+++ b/src/alerts/mode_4.rs
@@ -7,7 +7,7 @@ pub struct Mode4 {
 }
 
 impl AlertSystem for Mode4 {
-    fn new(_config: &TAWSConfig) -> Self {
+    fn new(_config: &TawsConfig) -> Self {
         Self {
             armed: false,
             inhibited: false,

--- a/src/alerts/mode_4.rs
+++ b/src/alerts/mode_4.rs
@@ -1,11 +1,17 @@
 use super::*;
 
 #[derive(Debug)]
-pub struct Mode4();
+pub struct Mode4 {
+    armed: bool,
+    inhibited: bool,
+}
 
 impl AlertSystem for Mode4 {
     fn new(_config: &TAWSConfig) -> Self {
-        Self()
+        Self {
+            armed: false,
+            inhibited: false,
+        }
     }
 
     fn is_armed(&self) -> bool {
@@ -13,15 +19,15 @@ impl AlertSystem for Mode4 {
     }
 
     fn is_inhibited(&self) -> bool {
-        unimplemented!()
+        self.inhibited
     }
 
     fn inhibit(&mut self) {
-        unimplemented!()
+        self.inhibited = true;
     }
 
     fn uninhibit(&mut self) {
-        unimplemented!()
+        self.inhibited = false;
     }
 
     fn process(&mut self, _state: &AircraftState) -> Option<AlertLevel> {

--- a/src/alerts/mode_5.rs
+++ b/src/alerts/mode_5.rs
@@ -7,7 +7,7 @@ pub struct Mode5 {
 }
 
 impl AlertSystem for Mode5 {
-    fn new(_config: &TAWSConfig) -> Self {
+    fn new(_config: &TawsConfig) -> Self {
         Self {
             armed: false,
             inhibited: false,

--- a/src/alerts/mode_5.rs
+++ b/src/alerts/mode_5.rs
@@ -4,6 +4,10 @@ use super::*;
 pub struct Mode5();
 
 impl AlertSystem for Mode5 {
+    fn new(_config: &TAWSConfig) -> Self {
+        Self()
+    }
+
     fn is_armed(&self) -> bool {
         false
     }

--- a/src/alerts/mode_5.rs
+++ b/src/alerts/mode_5.rs
@@ -1,11 +1,17 @@
 use super::*;
 
 #[derive(Debug)]
-pub struct Mode5();
+pub struct Mode5 {
+    armed: bool,
+    inhibited: bool,
+}
 
 impl AlertSystem for Mode5 {
     fn new(_config: &TAWSConfig) -> Self {
-        Self()
+        Self {
+            armed: false,
+            inhibited: false,
+        }
     }
 
     fn is_armed(&self) -> bool {
@@ -13,15 +19,15 @@ impl AlertSystem for Mode5 {
     }
 
     fn is_inhibited(&self) -> bool {
-        unimplemented!()
+        self.inhibited
     }
 
     fn inhibit(&mut self) {
-        unimplemented!()
+        self.inhibited = true;
     }
 
     fn uninhibit(&mut self) {
-        unimplemented!()
+        self.inhibited = false;
     }
 
     fn process(&mut self, _state: &AircraftState) -> Option<AlertLevel> {

--- a/src/alerts/pda.rs
+++ b/src/alerts/pda.rs
@@ -1,13 +1,13 @@
 use super::*;
 
 #[derive(Debug)]
-pub struct PDA {
+pub struct Pda {
     armed: bool,
     inhibited: bool,
 }
 
-impl AlertSystem for PDA {
-    fn new(_config: &TAWSConfig) -> Self {
+impl AlertSystem for Pda {
+    fn new(_config: &TawsConfig) -> Self {
         Self {
             armed: false,
             inhibited: false,

--- a/src/alerts/pda.rs
+++ b/src/alerts/pda.rs
@@ -1,11 +1,17 @@
 use super::*;
 
 #[derive(Debug)]
-pub struct PDA();
+pub struct PDA {
+    armed: bool,
+    inhibited: bool,
+}
 
 impl AlertSystem for PDA {
     fn new(_config: &TAWSConfig) -> Self {
-        Self()
+        Self {
+            armed: false,
+            inhibited: false,
+        }
     }
 
     fn is_armed(&self) -> bool {
@@ -13,15 +19,15 @@ impl AlertSystem for PDA {
     }
 
     fn is_inhibited(&self) -> bool {
-        unimplemented!()
+        self.inhibited
     }
 
     fn inhibit(&mut self) {
-        unimplemented!()
+        self.inhibited = true;
     }
 
     fn uninhibit(&mut self) {
-        unimplemented!()
+        self.inhibited = false;
     }
 
     fn process(&mut self, _state: &AircraftState) -> Option<AlertLevel> {

--- a/src/alerts/pda.rs
+++ b/src/alerts/pda.rs
@@ -4,6 +4,10 @@ use super::*;
 pub struct PDA();
 
 impl AlertSystem for PDA {
+    fn new(_config: &TAWSConfig) -> Self {
+        Self()
+    }
+
     fn is_armed(&self) -> bool {
         false
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,20 +22,20 @@ mod types;
 
 /// Represents one instance of a TAWS
 #[derive(Debug)]
-pub struct TAWS {
+pub struct Taws {
     /// `true` if the TAWS is armed
     ///
     /// There is no specific condition for changing this to `false`.
     pub armed: bool,
-    config: TAWSConfig,
-    ffac: functionalities::FFAC,
-    flta: functionalities::FLTA,
+    config: TawsConfig,
+    ffac: functionalities::Ffac,
+    flta: functionalities::Flta,
     mode1: functionalities::Mode1,
     mode2: functionalities::Mode2,
     mode3: functionalities::Mode3,
     mode4: functionalities::Mode4,
     mode5: functionalities::Mode5,
-    pda: functionalities::PDA,
+    pda: functionalities::Pda,
 }
 
 macro_rules! functionalities {
@@ -73,10 +73,10 @@ macro_rules! count {
     ( $x:tt $($xs:tt)* ) => (1usize + count!($($xs)*));
 }
 
-impl TAWS {
-    functionalities![FFAC, FLTA, Mode1, Mode2, Mode3, Mode4, Mode5, PDA];
+impl Taws {
+    functionalities![Ffac, Flta, Mode1, Mode2, Mode3, Mode4, Mode5, Pda];
 
-    /// Create a new instance of `TAWS`
+    /// Create a new instance of `Taws`
     ///  
     /// # Arguments
     ///
@@ -87,20 +87,20 @@ impl TAWS {
     /// ```
     /// use opentaws::prelude::*;
     ///
-    /// let config = TAWSConfig::default();
-    /// let taws = TAWS::new(config);
+    /// let config = TawsConfig::default();
+    /// let taws = Taws::new(config);
     /// ```
-    pub fn new(config: TAWSConfig) -> Self {
+    pub fn new(config: TawsConfig) -> Self {
         use alerts::*;
 
-        let ffac = functionalities::FFAC::new(&config);
-        let flta = functionalities::FLTA::new(&config);
+        let ffac = functionalities::Ffac::new(&config);
+        let flta = functionalities::Flta::new(&config);
         let mode1 = functionalities::Mode1::new(&config);
         let mode2 = functionalities::Mode2::new(&config);
         let mode3 = functionalities::Mode3::new(&config);
         let mode4 = functionalities::Mode4::new(&config);
         let mode5 = functionalities::Mode5::new(&config);
-        let pda = functionalities::PDA::new(&config);
+        let pda = functionalities::Pda::new(&config);
 
         Self {
             armed: true,
@@ -126,8 +126,8 @@ impl TAWS {
     ///
     /// ```
     /// # use opentaws::prelude::*;
-    /// # let config = TAWSConfig::default();
-    /// # let taws = TAWS::new(config);
+    /// # let config = TawsConfig::default();
+    /// # let taws = Taws::new(config);
     /// if taws.is_armed(Alert::Mode1) {
     ///     // ...
     /// }
@@ -146,8 +146,8 @@ impl TAWS {
     ///
     /// ```
     /// # use opentaws::prelude::*;
-    /// # let config = TAWSConfig::default();
-    /// # let taws = TAWS::new(config);
+    /// # let config = TawsConfig::default();
+    /// # let taws = Taws::new(config);
     /// if taws.is_inhibited(Alert::Mode1) {
     ///     // ...
     /// }
@@ -166,8 +166,8 @@ impl TAWS {
     ///
     /// ```
     /// # use opentaws::prelude::*;
-    /// # let config = TAWSConfig::default();
-    /// # let mut taws = TAWS::new(config);
+    /// # let config = TawsConfig::default();
+    /// # let mut taws = Taws::new(config);
     /// taws.inhibit(Alert::Mode1);
     ///
     /// assert!(taws.is_inhibited(Alert::Mode1));
@@ -186,8 +186,8 @@ impl TAWS {
     ///
     /// ```
     /// # use opentaws::prelude::*;
-    /// # let config = TAWSConfig::default();
-    /// # let mut taws = TAWS::new(config);
+    /// # let config = TawsConfig::default();
+    /// # let mut taws = Taws::new(config);
     /// taws.uninhibit(Alert::Mode1);
     ///
     /// assert_eq!(taws.is_inhibited(Alert::Mode1), false);
@@ -209,8 +209,8 @@ impl TAWS {
     ///
     /// ```
     /// # use opentaws::prelude::*;
-    /// # let config = TAWSConfig::default();
-    /// # let mut taws = TAWS::new(config);
+    /// # let config = TawsConfig::default();
+    /// # let mut taws = Taws::new(config);
     /// let aicraft_state = AircraftState::default();
     ///
     /// let alert_state = taws.process(&aicraft_state);
@@ -240,14 +240,14 @@ mod test {
     #[ignore] // TODO enable this tests once all alert systems are implemented
     #[test]
     fn check_all_alert_systems() {
-        let taws = TAWS::new(Default::default());
-        let _ = taws.is_armed(Alert::FFAC);
-        let _ = taws.is_armed(Alert::FLTA);
+        let taws = Taws::new(Default::default());
+        let _ = taws.is_armed(Alert::Ffac);
+        let _ = taws.is_armed(Alert::Flta);
         let _ = taws.is_armed(Alert::Mode1);
         let _ = taws.is_armed(Alert::Mode2);
         let _ = taws.is_armed(Alert::Mode3);
         let _ = taws.is_armed(Alert::Mode4);
         let _ = taws.is_armed(Alert::Mode5);
-        let _ = taws.is_armed(Alert::PDA);
+        let _ = taws.is_armed(Alert::Pda);
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -5,8 +5,8 @@
 
 pub use crate::{
     alerts::{Alert, AlertLevel, AlertState, AlertSystem},
-    types::{AircraftState, TAWSConfig},
-    TAWS,
+    types::{AircraftState, TawsConfig},
+    Taws,
 };
 
 pub use uom::si::{

--- a/src/signal_test.rs
+++ b/src/signal_test.rs
@@ -1,0 +1,67 @@
+//! This file shall provide filtering
+
+use crate::prelude::*;
+use ringbuffer::{AllocRingBuffer, RingBuffer};
+use uom::si::ratio::{ratio, Ratio};
+
+// TODO: What is wrong, if two values do not fit together?
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum UnplausibleSignal {
+    AltitudeGround,
+    AltitudeSea,
+    SpeedAir,
+    SpeedGround,
+    NotEnoughData,
+    //InternalError,
+    /// Time stamp is either equally aged or older than the last
+    Anachronistic,
+}
+
+#[derive(Debug)]
+pub struct SignalTest {
+    states: AllocRingBuffer<AircraftState>,
+}
+
+impl SignalTest {
+    pub fn new(config: &TAWSConfig) -> Self {
+        Self {
+            states: AllocRingBuffer::with_capacity(16),
+        }
+    }
+
+    pub fn check(
+        &mut self,
+        aircraft_state: AircraftState,
+    ) -> Result<AircraftState, UnplausibleSignal> {
+        // push new aircraft states
+        self.states.push(aircraft_state);
+
+        // check if enough aircraft states where gathered
+        if self.states.len() < self.states.capacity() {
+            return Err(UnplausibleSignal::NotEnoughData);
+        }
+
+        // check if the new aircraft state goes forward in time
+        let dt = self.states.get(-2).unwrap().timestamp - self.states.get(-1).unwrap().timestamp;
+        if Time::new::<second>(0.0) >= dt {
+            return Err(UnplausibleSignal::Anachronistic);
+        }
+
+        let last_state = self.states.get(-2).unwrap();
+        let current_state = self.states.get(-1).unwrap();
+
+        // check if altitude ground is negative
+        if current_state.altitude_ground < Length::new::<foot>(0.0) {
+            return Err(UnplausibleSignal::AltitudeGround);
+        }
+
+        // check if height change is plausible
+        let max_speed = last_state.speed_ground.max(current_state.speed_ground);
+        let d_altitude = current_state.altitude - last_state.altitude;
+        //if d_altitude > Ratio::new::<ratio>(1.5) * dt * max_speed  {
+        //    return Err(UnplausibleSignal::AltitudeSea);
+        //}
+
+        Ok(self.states.get(-1).unwrap().clone())
+    }
+}

--- a/src/terrain_server.rs
+++ b/src/terrain_server.rs
@@ -1,0 +1,32 @@
+use core::convert::{From,Into};
+
+use crate::prelude::*;
+
+
+pub trait TerrainServer {
+    fn elevation<T: Into<Position>>(&self, position:T)->Length;
+    fn nearest_runway<T: Into<Position>>(&self, position:T)->Runway;
+}
+
+pub struct Position {
+    latitude: Angle,
+    longitude: Angle,
+    altitude_sea: Length,
+}
+
+impl From<&AircraftState> for Position {
+    fn from(aircraft_state: AircraftState)->Self{
+        Position{
+            longitude: aircraft_state.longitude,
+            latitude: aircraft_state.latitude,
+            altitude_sea: aircraft_state.altitude_sea,
+        }
+    }
+}
+
+pub struct Runway {
+    location: Position,
+    length: Length,
+    name: String,
+    azimuth: Angle,
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -64,7 +64,7 @@ pub struct AircraftState {
 /// This configuration holds various details about the aircraft in use. These are necessary for
 /// example when estimating path trajectories for FLTA.
 #[derive(Clone, Debug)]
-pub struct TAWSConfig {
+pub struct TawsConfig {
     pub max_climbrate: Velocity,
     pub max_climbrate_change: Acceleration,
 }
@@ -114,7 +114,7 @@ impl fmt::Display for AircraftState {
     }
 }
 
-impl Default for TAWSConfig {
+impl Default for TawsConfig {
     fn default() -> Self {
         Self {
             max_climbrate: Velocity::new::<foot_per_minute>(700.0),

--- a/src/types.rs
+++ b/src/types.rs
@@ -14,6 +14,7 @@ use uom::{
 
 /// Represents the current state of an aircraft
 #[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "use-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AircraftState {
     /// Time when this aircraft state was emitted
     pub timestamp: Time,

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -12,7 +12,7 @@ struct ScenarioContext {}
 
 #[derive(Debug)]
 pub struct MyWorld {
-    taws: TAWS,
+    taws: Taws,
     template_frame: AircraftState,
     props: ScenarioProperties,
 }
@@ -32,7 +32,7 @@ impl cucumber::World for MyWorld {
 
     async fn new() -> Result<Self, Infallible> {
         Ok(Self {
-            taws: TAWS::new(Default::default()),
+            taws: Taws::new(Default::default()),
             template_frame: Default::default(),
             props: Default::default(),
         })
@@ -222,14 +222,14 @@ fn parse_alert<T: AsRef<str>>(from: &T) -> Alert {
     let mut input_word = from.as_ref().to_lowercase();
     input_word.retain(|c| !c.is_whitespace());
     match input_word.as_str() {
-        "ffac" => Alert::FFAC,
-        "flta" => Alert::FLTA,
+        "ffac" => Alert::Ffac,
+        "flta" => Alert::Flta,
         "mode1" => Alert::Mode1,
         "mode2" => Alert::Mode2,
         "mode3" => Alert::Mode3,
         "mode4" => Alert::Mode4,
         "mode5" => Alert::Mode5,
-        "pda" => Alert::PDA,
+        "pda" => Alert::Pda,
         _ => {
             panic!(
                 "unable to convert {} into a variant of `Alert`",

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -40,7 +40,7 @@ impl cucumber::World for MyWorld {
         Ok(Self {
             taws: Taws::new(Default::default()),
             mould_pipeline: Vec::new(),
-            test_length: 1000, // TODO is this a good number?
+            test_length: 10000, // TODO is this a good number?
         })
     }
 }


### PR DESCRIPTION
These commits pave the road towards `no_std` compatibility. The openTAWS code itself is now free of allocations and any other functionality which might need an OS. Some of the testing code needs to be overhauled, but this beyond the scope of this PR.